### PR TITLE
Fix now v2 to support articles on reload.

### DIFF
--- a/now.json
+++ b/now.json
@@ -3,9 +3,12 @@
   "alias": "casprer.now.sh",
   "public": true,
   "builds": [
-    { "src": "server.js", "use": "@now/node-server" },
     { "src": "next.config.js", "use": "@now/next@canary" },
-    { "src": "static/*", "use": "@now/static" },
+    { "src": "static/**", "use": "@now/static" },
     { "src": "static/fonts/", "use": "@now/static" }
+  ],
+  "routes": [
+    {"src": "/p/(?<id>.+)", "dest": "/article?slug=$id"},
+    {"src": "/(.*)", "dest": "/$1"}
   ]
 }


### PR DESCRIPTION
There is no need for custom servers in our current version of the platform.
Take a look at what I did in now.json and let me know if you have any questions.